### PR TITLE
Improve boot menu

### DIFF
--- a/IOS-Z80-MBC2.ino
+++ b/IOS-Z80-MBC2.ino
@@ -544,7 +544,6 @@ void setup()
       BootInfo = GetDiskSetBootInfo(diskSet);
       fileNameSD = BootInfo.BootFile;
       BootStrAddr = BootInfo.BootAddr;
-      Serial.printf(F("Booting file fileNameSD %s BootStrAddr %x\n\r"), fileNameSD, BootStrAddr);
     break;
     
     case 3:                                       // Load AUTOBOOT.BIN from SD (load an user executable binary file)
@@ -632,9 +631,7 @@ void setup()
     while (errCodeSD);
 
     // Read the selected file from SD and load it into RAM until an EOF is reached
-    Serial.print(F("IOS: Loading boot program ("));
-    Serial.print(fileNameSD);
-    Serial.print(F(")..."));
+    Serial.printf(F("IOS: Loading boot program (%s@0x%04x)..."), fileNameSD, BootStrAddr);
     do
     // If an error occurs repeat until error disappears (or the user forces a reset)
     {

--- a/IOS-Z80-MBC2.ino
+++ b/IOS-Z80-MBC2.ino
@@ -450,7 +450,7 @@ void setup()
       printOsName(diskSet);
       Serial.println(F("\r\n 4: Autoboot"));
       Serial.println(F(" 5: iLoad"));
-      Serial.printf(F(" 6: Change Z80 clock speed (->%dMHz)\r\n"), clockMode ? CLOCK_HIGH : CLOCK_LOW);
+      Serial.printf(F(" 6: Change Z80 clock speed (->%dMHz)\r\n"), clockMode ? CLOCK_LOW : CLOCK_HIGH);
       Serial.print(F(" 7: Toggle CP/M Autoexec (->"));
       if (autoexecFlag) Serial.print(F("ON"));
       else Serial.print(F("OFF"));
@@ -673,7 +673,7 @@ void setup()
   TCCR2 &= ~(1 << WGM20);
   TCCR2 |= (1 <<  COM20);                         // Set "toggle OC2 on compare match"
   TCCR2 &= ~(1 << COM21);
-  OCR2 = clockMode;                               // Set the compare value to toggle OC2 (0 = low or 1 = high)
+  OCR2 = clockMode;                               // Set the compare value to toggle OC2 (0 = high or 1 = low)
   pinMode(CLK, OUTPUT);                           // Set OC2 as output and start to output the clock
   Serial.println(F("IOS: Z80 is running from now"));
   Serial.println();


### PR DESCRIPTION
The following improvements to the boot menu have been made in this set of changes:

1. Selecting a settings menu item returns you to the boot menu once it setting has been changed.
2. Selecting which disk set to use to boot from is now a menu making it easier to select the disk set.
3. Additional disk sets can be added without out having to use Autoboot by specifying the OS Name, Boot File and Boot Address it a .TXT file instead of the .DAT file with just the OS Name.
4. Made more use of the printf function to simplify display code.